### PR TITLE
Add date grouping and improved time formatting in chat view

### DIFF
--- a/lib/core/extensions/extensions.dart
+++ b/lib/core/extensions/extensions.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 extension StringsListExtension on List<String> {
   String generateChatId() {
     final userId1 = this[0];
@@ -8,10 +10,8 @@ extension StringsListExtension on List<String> {
 }
 
 extension TimeExtension on int {
-  String formatTime() {
+  String formatIntTime() {
     final DateTime time = DateTime.fromMillisecondsSinceEpoch(this);
-    final String formattedTime =
-        "${time.hour}:${time.minute.toString().padLeft(2, '0')}";
-    return formattedTime;
+    return DateFormat('hh:mm a').format(time);
   }
 }

--- a/lib/core/utils/app_strings.dart
+++ b/lib/core/utils/app_strings.dart
@@ -52,4 +52,6 @@ abstract class AppStrings {
   static const String noChats = "No chats found";
   static const String users = "Users";
   static const String sendMessageHint = "Type a message...";
+  static const String today = "Today";
+  static const String yesterday = "Yesterday";
 }

--- a/lib/features/chat/ui/widgets/chat/chat_view_date_item.dart
+++ b/lib/features/chat/ui/widgets/chat/chat_view_date_item.dart
@@ -1,0 +1,48 @@
+import 'package:chat/core/utils/app_strings.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ChatViewDateItem extends StatelessWidget {
+  const ChatViewDateItem({super.key, required this.date});
+  final DateTime date;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            vertical: 4,
+            horizontal: 8,
+          ),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.primary,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Text(
+            _formatDate(date),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+  final today = DateTime.now();
+  final yesterday = today.subtract(const Duration(days: 1));
+
+  if (DateUtils.isSameDay(date, today)) {
+    return AppStrings.today;
+  } else if (DateUtils.isSameDay(date, yesterday)) {
+    return AppStrings.yesterday;
+  } else {
+    return DateFormat('dd/MM/yyyy').format(date);
+  }
+}
+}

--- a/lib/features/chat/ui/widgets/chat/chat_view_message_item.dart
+++ b/lib/features/chat/ui/widgets/chat/chat_view_message_item.dart
@@ -57,7 +57,7 @@ class ChatViewMessageItem extends StatelessWidget {
             Align(
               alignment: Alignment.bottomRight,
               child: Text(
-                message.time.formatTime(),
+                message.time.formatIntTime(),
                 style: TextStyle(
                   color: isMyMessage
                       ? Theme.of(context).colorScheme.primary

--- a/lib/features/chat/ui/widgets/chat/chat_view_success.dart
+++ b/lib/features/chat/ui/widgets/chat/chat_view_success.dart
@@ -1,24 +1,101 @@
 import 'package:flutter/material.dart';
 
 import '../../../models/message_model.dart';
+import 'chat_view_date_item.dart';
 import 'chat_view_message_item.dart';
 
-class ChatViewSuccess extends StatelessWidget {
+class ChatViewSuccess extends StatefulWidget {
   const ChatViewSuccess({
     super.key,
     required this.messages,
   });
+
   final List<MessageModel> messages;
 
   @override
+  State<ChatViewSuccess> createState() => _ChatViewSuccessState();
+}
+
+class _ChatViewSuccessState extends State<ChatViewSuccess> {
+  final ScrollController _scrollController = ScrollController();
+  List<dynamic> _previousMessages = [];
+
+  @override
   Widget build(BuildContext context) {
+    final groupedMessages = _groupMessagesByDate(widget.messages);
+
     return ListView.builder(
-      reverse: true,
-      itemCount: messages.length,
+      controller: _scrollController,
+      itemCount: groupedMessages.length,
       itemBuilder: (context, index) {
-        final message = messages[index];
-        return ChatViewMessageItem(message: message);
+        final item = groupedMessages[index];
+
+        if (item is DateTime) {
+          return ChatViewDateItem(date: item);
+        } else if (item is MessageModel) {
+          return ChatViewMessageItem(message: item);
+        } else {
+          return const SizedBox();
+        }
       },
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _previousMessages = widget.messages;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scrollToBottom();
+    });
+  }
+
+  @override
+  void didUpdateWidget(ChatViewSuccess oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.messages.length > _previousMessages.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _scrollToBottom();
+      });
+    }
+    _previousMessages = widget.messages;
+  }
+
+  void _scrollToBottom() {
+    if (_scrollController.hasClients) {
+      final double maxScroll = _scrollController.position.maxScrollExtent;
+      _scrollController.animateTo(
+        maxScroll + 500,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  List<dynamic> _groupMessagesByDate(List<MessageModel> messages) {
+    final List<dynamic> groupedMessages = [];
+    DateTime? currentDate;
+
+    for (final message in messages.reversed) {
+      final messageDate =
+          DateTime.fromMillisecondsSinceEpoch(message.time).toLocal();
+      final dateOnly =
+          DateTime(messageDate.year, messageDate.month, messageDate.day);
+
+      if (currentDate == null || currentDate != dateOnly) {
+        currentDate = dateOnly;
+        groupedMessages.add(currentDate);
+      }
+      groupedMessages.add(message);
+    }
+
+    return groupedMessages;
   }
 }

--- a/lib/features/chat/ui/widgets/chats/chats_view_item.dart
+++ b/lib/features/chat/ui/widgets/chats/chats_view_item.dart
@@ -43,7 +43,7 @@ class ChatsViewItem extends StatelessWidget {
             ),
       ),
       trailing: Text(
-        chat.lastMessageTime.formatTime(),
+        chat.lastMessageTime.formatIntTime(),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -472,6 +472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "00f33b908655e606b86d2ade4710a231b802eec6f11e87e4ea3783fd72077a50"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.1"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   flutter_svg: ^2.0.15
   get_it: ^8.0.2
   google_sign_in: ^6.2.2
+  intl: ^0.20.1
   pinput: ^5.0.0
   uuid: ^4.5.1
 


### PR DESCRIPTION
Introduce the `intl` package for flexible time formatting and update the `formatTime` method. 

Add a new `ChatViewDateItem` widget to display date separators, and modify `ChatViewSuccess` to group messages by date with automatic scrolling to the bottom for new messages.