### PR TITLE
Enhance chat fetching with pagination and error handling

### DIFF
--- a/lib/features/chat/data_sources/chats_data_source.dart
+++ b/lib/features/chat/data_sources/chats_data_source.dart
@@ -5,6 +5,8 @@ import '../models/chat_model.dart';
 
 abstract class ChatsDataSource {
   Stream<Either<Failure, List<ChatModel>>> fetchChats({
-  required String currentUserId,
-});
+    required String currentUserId,
+    int? limit,
+    ChatModel? lastChat,
+  });
 }

--- a/lib/features/chat/logic/chats/chats_state.dart
+++ b/lib/features/chat/logic/chats/chats_state.dart
@@ -9,17 +9,24 @@ class ChatsInitialState extends ChatsState {
 }
 
 class ChatsLoadingState extends ChatsState {
-  const ChatsLoadingState();
+  final List<ChatModel> currentChats;
+  final bool isLoadingMore;
+  const ChatsLoadingState({
+    this.currentChats = const [],
+    this.isLoadingMore = false,
+  });
 }
 
 class ChatsLoadedState extends ChatsState {
   final List<ChatModel> chats;
+  final bool hasMore;
 
-  const ChatsLoadedState(this.chats);
+  const ChatsLoadedState({required this.chats, this.hasMore = true});
 }
 
 class ChatsErrorState extends ChatsState {
   final String message;
+  final List<ChatModel> currentChats;
 
-  const ChatsErrorState(this.message);
+  const ChatsErrorState({required this.message, this.currentChats = const []});
 }

--- a/lib/features/chat/repos/chats_repository.dart
+++ b/lib/features/chat/repos/chats_repository.dart
@@ -6,5 +6,7 @@ import '../models/chat_model.dart';
 abstract class ChatsRepository {
   Stream<Either<Failure, List<ChatModel>>> fetchChats({
     required String currentUserId,
+    int? limit,
+    ChatModel? lastChat,
   });
 }

--- a/lib/features/chat/repos/firebase_chats_repository.dart
+++ b/lib/features/chat/repos/firebase_chats_repository.dart
@@ -14,8 +14,10 @@ class FirebaseChatsRepository implements ChatsRepository {
 
   @override
 Stream<Either<Failure, List<ChatModel>>> fetchChats({
-  required String currentUserId,
-}) {
+    required String currentUserId,
+    int? limit,
+    ChatModel? lastChat,
+  }) {
   return _chatsDataSource.fetchChats(currentUserId: currentUserId);
 }
 }

--- a/lib/features/chat/ui/views/chats_view.dart
+++ b/lib/features/chat/ui/views/chats_view.dart
@@ -35,7 +35,8 @@ class _ChatsViewState extends State<ChatsView> {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (context) => ChatsCubit(chatsRepository: getIt())
-        ..fetchChats((context.read<AuthCubit>().currentUser!.id)),
+        ..fetchChats(
+            currentUserId: (context.read<AuthCubit>().currentUser!.id)),
       child: Scaffold(
         appBar: AppBar(
           title: const Text(AppStrings.chats),

--- a/lib/features/chat/ui/widgets/chats/chats_view_body.dart
+++ b/lib/features/chat/ui/widgets/chats/chats_view_body.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../../../../../core/utils/app_strings.dart';
+import '../../../../auth/logic/auth_cubit.dart';
 import '../../../logic/chats/chats_cubit.dart';
 import '../../../logic/chats/chats_state.dart';
+import 'chats_view_error.dart';
 import 'chats_view_success.dart';
 
 class ChatsViewBody extends StatelessWidget {
@@ -13,21 +14,29 @@ class ChatsViewBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ChatsCubit, ChatsState>(
       builder: (context, state) {
-        if (state is ChatsLoadedState) {
-          if (state.chats.isEmpty) {
-            return const Center(
-              child: Text(AppStrings.noChats),
-            );
-          }
-          return ChatsViewSuccess(chats: state.chats);
-        } else if (state is ChatsErrorState) {
-          return Center(
-            child: Text(state.message),
-          );
-        }
-        return const Center(
-          child: CircularProgressIndicator(),
-        );
+        final currentUserId = (context.read<AuthCubit>().currentUser!.id);
+        return switch (state) {
+          ChatsErrorState() => ChatsViewError(
+              currentUserId: currentUserId,
+              state: state,
+            ),
+          ChatsLoadingState(isLoadingMore: false) =>
+            const Center(child: CircularProgressIndicator()),
+          ChatsLoadingState(isLoadingMore: true) => ChatsViewSuccess(
+              chats: state.currentChats,
+              currentUserId: currentUserId,
+              hasMore: true,
+              isLoading: true,
+            ),
+          ChatsLoadedState() => ChatsViewSuccess(
+              chats: state.chats,
+              currentUserId: currentUserId,
+              hasMore: state.hasMore,
+              isLoading: false,
+            ),
+          ChatsInitialState() =>
+            const Center(child: CircularProgressIndicator()),
+        };
       },
     );
   }

--- a/lib/features/chat/ui/widgets/chats/chats_view_error.dart
+++ b/lib/features/chat/ui/widgets/chats/chats_view_error.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../logic/chats/chats_cubit.dart';
+import '../../../logic/chats/chats_state.dart';
+import 'chats_view_success.dart';
+
+class ChatsViewError extends StatelessWidget {
+  const ChatsViewError({
+    super.key,
+    required this.currentUserId,
+    required this.state,
+  });
+
+  final String currentUserId;
+  final ChatsErrorState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            children: [
+              Expanded(child: Text(state.message)),
+              IconButton(
+                onPressed: () {
+                  context
+                      .read<ChatsCubit>()
+                      .loadMoreChats(currentUserId: currentUserId);
+                },
+                icon: const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+          if (state.currentChats.isNotEmpty)
+            Expanded(
+              child: ChatsViewSuccess(
+                chats: state.currentChats,
+                currentUserId: currentUserId,
+                hasMore: false,
+                isLoading: false,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/chat/ui/widgets/chats/chats_view_success.dart
+++ b/lib/features/chat/ui/widgets/chats/chats_view_success.dart
@@ -1,20 +1,77 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../logic/chats/chats_cubit.dart';
+import '../../../logic/chats/chats_state.dart';
 import '../../../models/chat_model.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../../core/widgets/spaces.dart';
 import 'chats_view_item.dart';
 
-class ChatsViewSuccess extends StatelessWidget {
-  const ChatsViewSuccess({super.key, required this.chats});
+class ChatsViewSuccess extends StatefulWidget {
+  const ChatsViewSuccess({
+    super.key,
+    required this.chats,
+    required this.currentUserId,
+    required this.hasMore,
+    required this.isLoading,
+  });
   final List<ChatModel> chats;
+  final String currentUserId;
+  final bool hasMore;
+  final bool isLoading;
+
+  @override
+  State<ChatsViewSuccess> createState() => _ChatsViewSuccessState();
+}
+
+class _ChatsViewSuccessState extends State<ChatsViewSuccess> {
+  final ScrollController _scrollController = ScrollController();
+  bool _isLoadingMore = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      if ((!_isLoadingMore && widget.hasMore) ||
+          ((context.read<ChatsCubit>().state is ChatsErrorState) &&
+              widget.hasMore)) {
+        _isLoadingMore = true;
+        context
+            .read<ChatsCubit>()
+            .loadMoreChats(currentUserId: widget.currentUserId);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return ListView.separated(
-      itemCount: chats.length,
+      controller: _scrollController,
+      itemCount: (widget.hasMore ? 1 : 0) + (widget.chats.length),
       separatorBuilder: (context, index) => const VerticalSpace(height: 8),
       itemBuilder: (context, index) {
-        final chat = chats[index];
+        if (index == (widget.chats.length) && widget.hasMore) {
+          return const Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+        final chat = widget.chats[index];
         return ChatsViewItem(chat: chat);
       },
     );


### PR DESCRIPTION
Improve the `fetchChats` method to support pagination and filtering, allowing for more efficient chat data retrieval. 

Refactor the `ChatsCubit` for better state management and introduce a new `ChatsViewError` widget to handle loading errors. 

Implement infinite scrolling in the `ChatsViewSuccess` widget to enhance user experience.