### PR TITLE
Remove duplicate messages and chats; fix media URL check

### DIFF
--- a/lib/features/chat/logic/chat/chat_cubit.dart
+++ b/lib/features/chat/logic/chat/chat_cubit.dart
@@ -21,6 +21,7 @@ class ChatCubit extends Cubit<ChatState> {
       : _chatRepository = chatRepository,
         super(const ChatInitialState());
 
+
   
   List<MessageModel> _getCurrentMessages() {
     return switch (state) {
@@ -62,11 +63,16 @@ class ChatCubit extends Cubit<ChatState> {
             );
           },
           (newMessages) {
-            final currentMessages = _getCurrentMessages();
-            final mergedMessages = {
+            var currentMessages = List<MessageModel>.from(_getCurrentMessages());
+            currentMessages.removeWhere((message) {
+              return newMessages.any((e) {
+                return e.id == message.id;
+              });
+            });
+            final mergedMessages = [
               ...newMessages,
               ...currentMessages,
-            }.toList();
+            ];
             final hasMore = currentMessages.isNotEmpty
                 ? _getHasMore()
                 : newMessages.length >= _pageSize;
@@ -83,7 +89,7 @@ class ChatCubit extends Cubit<ChatState> {
 
   void loadMoreMessages({required String chatId}) {
     if (!_getHasMore()) return;
-    final currentMessages = _getCurrentMessages();
+    var currentMessages = List<MessageModel>.from(_getCurrentMessages());
     final lastMessage =
         currentMessages.isNotEmpty ? currentMessages.last : null;
 
@@ -108,6 +114,11 @@ class ChatCubit extends Cubit<ChatState> {
             ));
           },
           (newMessages) {
+            currentMessages.removeWhere((message) {
+              return newMessages.any((e) {
+                return e.id == message.id;
+              });
+            });
             final updatedMessages = [
               ...currentMessages,
               ...newMessages,

--- a/lib/features/chat/logic/chats/chats_cubit.dart
+++ b/lib/features/chat/logic/chats/chats_cubit.dart
@@ -58,11 +58,16 @@ class ChatsCubit extends Cubit<ChatsState> {
             );
           },
           (newChats) {
-            final currentChats = _getCurrentChats();
-            final mergedChats = {
+            var currentChats = List<ChatModel>.from(_getCurrentChats());
+            currentChats.removeWhere((chat) {
+              return newChats.any((e) {
+                return e.id == chat.id;
+              });
+            });
+            final mergedChats = [
               ...newChats,
               ...currentChats,
-            }.toList();
+            ];
             final hasMore = currentChats.isNotEmpty
                 ? _getHasMore()
                 : newChats.length >= _pageSize;
@@ -79,7 +84,7 @@ class ChatsCubit extends Cubit<ChatsState> {
 
   void loadMoreChats({required String currentUserId}) {
     if (!_getHasMore()) return;
-    final currentChats = _getCurrentChats();
+    var currentChats = List<ChatModel>.from(_getCurrentChats());
     final lastChat = currentChats.isNotEmpty ? currentChats.last : null;
 
     emit(ChatsLoadingState(
@@ -103,6 +108,11 @@ class ChatsCubit extends Cubit<ChatsState> {
             ));
           },
           (newChats) {
+            currentChats.removeWhere((chat) {
+              return newChats.any((e) {
+                return e.id == chat.id;
+              });
+            });
             final updatedChats = [
               ...currentChats,
               ...newChats,

--- a/lib/features/chat/ui/widgets/chat/message_image_item.dart
+++ b/lib/features/chat/ui/widgets/chat/message_image_item.dart
@@ -25,9 +25,11 @@ class MessageImageItem extends StatelessWidget {
     final bool isMyMessage =
         message.senderId == context.read<AuthCubit>().currentUser!.id;
 
-    final isRemoteUrl = Uri.tryParse(message.mediaUrl ?? AppStrings.emptyString)
-            ?.hasAbsolutePath ??
-        false;
+    final isRemoteUrl =
+        (Uri.tryParse(message.mediaUrl ?? AppStrings.emptyString)
+                    ?.hasAbsolutePath ??
+                false) &&
+            message.mediaUrl!.contains('http');
 
     final isLocalFile =
         File(message.mediaUrl ?? AppStrings.emptyString).existsSync();


### PR DESCRIPTION
Eliminate duplicate messages and chats during data merging in `ChatCubit` and `ChatsCubit`. 

Update the media URL check in `MessageImageItem` to ensure accurate identification of remote URLs.